### PR TITLE
Add initial Kinesis Event Record Model

### DIFF
--- a/src/aws_lambda_event_models/__init__.py
+++ b/src/aws_lambda_event_models/__init__.py
@@ -32,7 +32,7 @@ class Kinesis(BaseModel):
             "partition_key": "partitionKey",
             "sequence_number": "sequenceNumber",
             "approximate_arrival_timestamp": "approximateArrivalTimestamp",
-            'decoded_data': 'data',
+            "decoded_data": "data",
         }
 
 

--- a/src/aws_lambda_event_models/__init__.py
+++ b/src/aws_lambda_event_models/__init__.py
@@ -1,5 +1,6 @@
 """Top-level package for aws-lambda-event-models."""
 
+from base64 import b64decode
 from datetime import datetime
 from enum import Enum
 
@@ -11,8 +12,64 @@ __email__ = "kelton.karboviak@gmail.com"
 __version__ = "0.0.1"
 
 
+class Base64Str(str):
+    """base64 encoded data validation."""
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        if not isinstance(v, (bytes, str)):
+            raise TypeError(f'bytes or string required, received {type(v)}')
+        decoded = b64decode(v).decode('utf8')
+        return cls(decoded)
+
+    def __repr__(self):
+        return f'Base64({super().__repr__()})'
+
+
 class EventSource(str, Enum):
+    kinesis = "aws:kinesis"
     s3 = "aws:s3"
+
+
+class Kinesis(BaseModel):
+    schema_version: str
+    partition_key: str
+    sequence_number: str
+    approximate_arrival_timestamp: datetime
+    data: str
+    decoded_data: Base64Str = None
+
+    class Config:
+        fields = {
+            "schema_version": "kinesisSchemaVersion",
+            "partition_key": "partitionKey",
+            "sequence_number": "sequenceNumber",
+            "approximate_arrival_timestamp": "approximateArrivalTimestamp",
+            'decoded_data': 'data',
+        }
+
+
+class KinesisEventRecord(BaseModel):
+    event_version: str
+    event_source: EventSource
+    aws_region: str
+    event_name: str
+    event_id: str
+    event_source_arn: str
+    kinesis: Kinesis
+
+    class Config:
+        fields = {
+            "event_version": "eventVersion",
+            "event_source": "eventSource",
+            "aws_region": "awsRegion",
+            "event_name": "eventName",
+            "event_id": "eventID",
+            "event_source_arn": "eventSourceARN",
+        }
 
 
 class S3Bucket(BaseModel):

--- a/src/aws_lambda_event_models/__init__.py
+++ b/src/aws_lambda_event_models/__init__.py
@@ -1,32 +1,16 @@
 """Top-level package for aws-lambda-event-models."""
 
-from base64 import b64decode
 from datetime import datetime
 from enum import Enum
 
 from pydantic import BaseModel
 
+from .types import Base64Str
+
 
 __author__ = """Kelton Karboviak"""
 __email__ = "kelton.karboviak@gmail.com"
 __version__ = "0.0.1"
-
-
-class Base64Str(str):
-    """base64 encoded data validation."""
-    @classmethod
-    def __get_validators__(cls):
-        yield cls.validate
-
-    @classmethod
-    def validate(cls, v):
-        if not isinstance(v, (bytes, str)):
-            raise TypeError(f'bytes or string required, received {type(v)}')
-        decoded = b64decode(v).decode('utf8')
-        return cls(decoded)
-
-    def __repr__(self):
-        return f'Base64({super().__repr__()})'
 
 
 class EventSource(str, Enum):

--- a/src/aws_lambda_event_models/newsfragments/4.feature
+++ b/src/aws_lambda_event_models/newsfragments/4.feature
@@ -1,0 +1,1 @@
+Added model for Kinesis Lambda Event. Matching the AWS Docs here: https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html.

--- a/src/aws_lambda_event_models/types.py
+++ b/src/aws_lambda_event_models/types.py
@@ -1,0 +1,18 @@
+from base64 import b64decode
+
+
+class Base64Str(str):
+    """base64 encoded data validation."""
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        if not isinstance(v, (bytes, str)):
+            raise TypeError(f'bytes or string required, received {type(v)}')
+        decoded = b64decode(v).decode('utf8')
+        return cls(decoded)
+
+    def __repr__(self):
+        return f'Base64({super().__repr__()})'

--- a/src/aws_lambda_event_models/types.py
+++ b/src/aws_lambda_event_models/types.py
@@ -3,6 +3,7 @@ from base64 import b64decode
 
 class Base64Str(str):
     """base64 encoded data validation."""
+
     @classmethod
     def __get_validators__(cls):
         yield cls.validate
@@ -10,9 +11,9 @@ class Base64Str(str):
     @classmethod
     def validate(cls, v):
         if not isinstance(v, (bytes, str)):
-            raise TypeError(f'bytes or string required, received {type(v)}')
-        decoded = b64decode(v).decode('utf8')
+            raise TypeError(f"bytes or string required, received {type(v)}")
+        decoded = b64decode(v).decode("utf8")
         return cls(decoded)
 
     def __repr__(self):
-        return f'Base64({super().__repr__()})'
+        return f"Base64({super().__repr__()})"

--- a/tests/aws_lambda_event_models_test.py
+++ b/tests/aws_lambda_event_models_test.py
@@ -75,21 +75,36 @@ def test_correctly_parse_valid_kinesis_event_record(kinesis_event_record):
 
     # top-level fields
     assert "1.0" == record.event_version
-    assert "aws:kinesis" == record.event_source and EventSource.kinesis == record.event_source
+    assert (
+        "aws:kinesis" == record.event_source
+        and EventSource.kinesis == record.event_source
+    )
     assert "us-east-2" == record.aws_region
     assert "aws:kinesis:record" == record.event_name
-    assert "shardId-000000000006:49590338271490256608559692538361571095921575989136588898" == record.event_id
-    assert "arn:aws:kinesis:us-east-2:123456789012:stream/lambda-stream" == record.event_source_arn
+    assert (
+        "shardId-000000000006:49590338271490256608559692538361571095921575989136588898"
+        == record.event_id
+    )
+    assert (
+        "arn:aws:kinesis:us-east-2:123456789012:stream/lambda-stream"
+        == record.event_source_arn
+    )
 
     # kinesis fields
     kinesis_metadata = record.kinesis
     assert "1.0" == kinesis_metadata.schema_version
 
     assert "1" == kinesis_metadata.partition_key
-    assert "49590338271490256608559692538361571095921575989136588898" == kinesis_metadata.sequence_number
+    assert (
+        "49590338271490256608559692538361571095921575989136588898"
+        == kinesis_metadata.sequence_number
+    )
     assert "SGVsbG8sIHRoaXMgaXMgYSB0ZXN0Lg==" == kinesis_metadata.data
     assert "Hello, this is a test." == kinesis_metadata.decoded_data
-    assert datetime(2018, 12, 17, 22, 10, 50, 987000, tzinfo=timezone.utc) == kinesis_metadata.approximate_arrival_timestamp
+    assert (
+        datetime(2018, 12, 17, 22, 10, 50, 987000, tzinfo=timezone.utc)
+        == kinesis_metadata.approximate_arrival_timestamp
+    )
 
 
 def test_correctly_parse_valid_s3_event_record(s3_event_record):

--- a/tests/types_test.py
+++ b/tests/types_test.py
@@ -12,7 +12,7 @@ class DummyBase64StrModel(BaseModel):
 
 @pytest.fixture()
 def fake_data():
-    return 'Hello this is a test.'
+    return 'Hello, this is a test.'
 
 
 @pytest.fixture()

--- a/tests/types_test.py
+++ b/tests/types_test.py
@@ -1,0 +1,42 @@
+from base64 import b64encode
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from aws_lambda_event_models import types
+
+
+class DummyBase64StrModel(BaseModel):
+    data: types.Base64Str
+
+
+@pytest.fixture()
+def fake_data():
+    return 'Hello this is a test.'
+
+
+@pytest.fixture()
+def encoded_fake_data(fake_data):
+    return b64encode(fake_data.encode('utf8'))
+
+
+def test_base64_str_properly_decodes_str(fake_data, encoded_fake_data):
+    m = DummyBase64StrModel(data=encoded_fake_data.decode("utf8"))
+
+    assert fake_data == m.data
+
+
+def test_base64_str_properly_decodes_bytes(fake_data, encoded_fake_data):
+    m = DummyBase64StrModel(data=encoded_fake_data)
+
+    assert fake_data == m.data
+
+
+def test_base64_str_raises_validation_error_when_not_bytes_or_str(fake_data, encoded_fake_data):
+    with pytest.raises(ValidationError):
+        DummyBase64StrModel(data=123)
+
+
+def test_base64_str_raises_validation_error_when_data_not_properly_base64_encoded(fake_data, encoded_fake_data):
+    with pytest.raises(ValidationError) as excinfo:
+        DummyBase64StrModel(data='XXXX')

--- a/tests/types_test.py
+++ b/tests/types_test.py
@@ -12,12 +12,12 @@ class DummyBase64StrModel(BaseModel):
 
 @pytest.fixture()
 def fake_data():
-    return 'Hello, this is a test.'
+    return "Hello, this is a test."
 
 
 @pytest.fixture()
 def encoded_fake_data(fake_data):
-    return b64encode(fake_data.encode('utf8'))
+    return b64encode(fake_data.encode("utf8"))
 
 
 def test_base64_str_properly_decodes_str(fake_data, encoded_fake_data):
@@ -32,11 +32,15 @@ def test_base64_str_properly_decodes_bytes(fake_data, encoded_fake_data):
     assert fake_data == m.data
 
 
-def test_base64_str_raises_validation_error_when_not_bytes_or_str(fake_data, encoded_fake_data):
+def test_base64_str_raises_validation_error_when_not_bytes_or_str(
+    fake_data, encoded_fake_data
+):
     with pytest.raises(ValidationError):
         DummyBase64StrModel(data=123)
 
 
-def test_base64_str_raises_validation_error_when_data_not_properly_base64_encoded(fake_data, encoded_fake_data):
+def test_base64_str_raises_validation_error_when_data_not_properly_base64_encoded(
+    fake_data, encoded_fake_data
+):
     with pytest.raises(ValidationError) as excinfo:
-        DummyBase64StrModel(data='XXXX')
+        DummyBase64StrModel(data="XXXX")


### PR DESCRIPTION
Closes https://github.com/KeltonKarboviak/aws-lambda-event-models/issues/4.

* Adds `aws_lambda_event_models.types` module
  * Currently, only has `Base64Str` pydantic type with tests
* Adds `KinesisEventRecord` model
* Adds test for new model